### PR TITLE
Adds npm start script and alternative CREDENTIALS option

### DIFF
--- a/cronJob.js
+++ b/cronJob.js
@@ -3,24 +3,39 @@ const cron = require('node-cron');
 const getDailyVolume = require('./index');
 const sheetService = require('./sheetService');
 
-// Load client secrets from a local file.
-fs.readFile('credentials.json', (err, content) => {
-  if (err) {
-    console.log('Error loading client secret file:', err);
-    return console.log('Please refer to the README.md for instructions on generating the credentials.json file.');
-  }
-  // Authorize a client with credentials, then call the Google Sheets API.
-  sheetService.authorize(JSON.parse(content), (auth) => {
-    console.log('CRON job is running...');
-    cron.schedule('1 0 * * *', async () => {
-      console.log('Scheduled CRON job is being run.');
-      const volume = await getDailyVolume();
-      const date = new Date();
-      date.setDate(date.getDate());
-      const formattedDate = `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
+schedule = () => {
+  getAuth( (err, content) => {
 
-      sheetService.writeToSheet(auth, [[formattedDate, volume]]);
-      console.log(`CRON job finished, current volume is ${volume}, date ${formattedDate}`);
+    if (err) {
+      console.log('Error loading client secret file:', err);
+      return console.log('Please refer to the README.md for instructions on generating the credentials.json file.');
+    }
+
+    // Authorize a client with credentials, then call the Google Sheets API.
+    sheetService.authorize(JSON.parse(content), (auth) => {
+      console.log('CRON job is running...');
+      cron.schedule('1 0 * * *', async () => {
+        console.log('Scheduled CRON job is being run.');
+        const volume = await getDailyVolume();
+        const date = new Date();
+        date.setDate(date.getDate());
+        const formattedDate = `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
+
+        sheetService.writeToSheet(auth, [[formattedDate, volume]]);
+        console.log(`CRON job finished, current volume is ${volume}, date ${formattedDate}`);
+      });
     });
   });
-});
+}
+
+getAuth = (done) => {
+  let auth
+
+  if(process.env.CREDENTIALS) {
+    return done(null, process.env.CREDENTIALS)
+  }
+
+  fs.readFile('credentials.json', done)
+}
+
+schedule()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Fetch daily volume for efx trustless",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node cronJob.js"
   },
   "author": "Nikola Vukovic (nvukovic@decenter.com)",
   "license": "ISC",


### PR DESCRIPTION
I'm not sure if the authentication on the sheets will happen smoothly this way because locally it was asking me to copy a code.

Perhaps when it's deployed and the address becomes available on the www it will do the authentication automatically.

Once it's deployed we just need to check the logs, either with `heroku logs` or through the "papertrail addon" which was added to the project on Heroku.